### PR TITLE
Fixing argument splitting

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -18,7 +18,7 @@ done
 # Create a wrapper so we can run the binaries without entering a shell
 cat > $out/cinc-workstation/bin/cw-wrapper <<EOF
 #!$SHELL
-/opt/cinc-workstation/bin/\$@
+/opt/cinc-workstation/bin/"\$@"
 EOF
 chmod +x $out/cinc-workstation/bin/cw-wrapper
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           installPhase = ''
             mkdir -p $out/bin
             for bin in $src/cinc-workstation/bin/*; do
-              echo -e "#!/usr/bin/env bash\n$buildInputs/bin/cinc-workstation-run $(basename $bin) \$@" > $out/bin/$(basename $bin)
+              echo -e "#!/usr/bin/env bash\n$buildInputs/bin/cinc-workstation-run $(basename $bin) \"\$@\"" > $out/bin/$(basename $bin)
               chmod +x $out/bin/$(basename $bin)
             done
           '';


### PR DESCRIPTION
Fixed argument splitting by using double quotes around $@ in wrapper scripts